### PR TITLE
Use input.name as tag in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,6 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           commit: master
-          tag: ${{ github.run_number }}
+          tag: ${{ inputs.name }}
           name: ${{ inputs.name }}
           artifacts: "graphite-linux-x86_64/graphite-x86_64.AppImage,graphite-windows-x86_64/graphite-windows-x86_64.zip"


### PR DESCRIPTION
This PR does one thing:
makes it so that the tag of a new release isn't `run_number`. Instead it is set to the name of the release.
I believe this is how most other repositories do it.

The `run_number` didn't really contain much information about what exactly the tag meant.
This way it's also easier to checkout to older versions.

